### PR TITLE
Update unit file with F42 changes

### DIFF
--- a/locale1-x11-sync.service
+++ b/locale1-x11-sync.service
@@ -1,7 +1,11 @@
 [Unit]
 Description=Sync localed configuration with running X11 system
+Documentation=https://github.com/rhinstaller/localed-x11-sync
 
 [Service]
 Type=exec
 ExecStart=/usr/libexec/locale1-x11-sync
 Restart=on-failure
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
For Fedora 42 we have deployed the script and systemd service via the anaconda-live package, so lets sync back the changes we have done to the unit file, so that we don't miss anything if we deploy directly from this upstream repo in the future.